### PR TITLE
fix: allow Enter skip for optional AnyUrl None defaults

### DIFF
--- a/src/richforms/prompts.py
+++ b/src/richforms/prompts.py
@@ -31,7 +31,9 @@ def prompt_for_value(
         )
 
     while True:
-        default_text = _default_to_text(default_value) if has_default else None
+        default_text = None
+        if has_default and not (default_value is None and not node.required):
+            default_text = _default_to_text(default_value)
         prompt = prompt_path
         if not node.required:
             prompt = f"{prompt_path} ({optional_hint})"

--- a/tests/test_api_flow.py
+++ b/tests/test_api_flow.py
@@ -2,7 +2,7 @@ import warnings
 from pathlib import Path
 
 import pytest
-from pydantic import BaseModel, Field
+from pydantic import AnyUrl, BaseModel, Field
 
 from richforms import edit, fill
 from richforms.api import collect_model, edit_model
@@ -18,9 +18,23 @@ class SimpleModel(BaseModel):
     version: str = "1.0.0"
 
 
+class OptionalUrlModel(BaseModel):
+    name: str
+    source: AnyUrl
+    url: AnyUrl | None = None
+
+
 class InterruptModel(BaseModel):
     name: str
     description: str | None = None
+
+
+class PromptDefaultInteraction(ScriptedInteraction):
+    def ask(self, prompt: str, default: str | None = None) -> str:
+        value = super().ask(prompt, default=default)
+        if value == "" and default is not None:
+            return default
+        return value
 
 
 class ExcludedLeafPromptModel(BaseModel):
@@ -61,6 +75,22 @@ def test_collect_model_supports_default_enter() -> None:
     assert model.name == "Image"
     assert model.source == "https://example.com/repo"
     assert model.version == "1.0.0"
+
+
+def test_fill_optional_anyurl_accepts_enter_with_none_default() -> None:
+    interaction = PromptDefaultInteraction(
+        responses=[
+            "Image",
+            "https://example.com/repo",
+            "",
+        ],
+        confirmations=[True],
+    )
+    config = FormConfig(interaction=interaction)
+
+    model = fill(OptionalUrlModel, config=config)
+
+    assert model.url is None
 
 
 def test_collect_model_reprompts_only_invalid_field_after_validation() -> None:


### PR DESCRIPTION
## Summary
- fix prompt default handling so optional fields with a `None` default do not set a textual default value
- add a regression test for `AnyUrl | None = None` to ensure pressing Enter keeps `None`
- preserve existing default-enter behavior for non-`None` defaults

## Test Plan
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run ty check --output-format github .`
- [x] `uv run pytest -q`

Closes #8
